### PR TITLE
Add branding settings page

### DIFF
--- a/src/app/api/settings/route.ts
+++ b/src/app/api/settings/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from 'next/server'
+import { supabase } from '@/lib/supabase'
+
+export async function GET() {
+  try {
+    const { data, error } = await supabase
+      .from('settings')
+      .select('*')
+
+    if (error) {
+      console.error('Error fetching settings:', error)
+      return NextResponse.json(
+        { error: 'Failed to fetch settings' },
+        { status: 500 }
+      )
+    }
+
+    // Transform results into key-value map
+    const settings: Record<string, string> = {}
+    for (const row of data || []) {
+      settings[row.key] = row.value
+    }
+
+    return NextResponse.json({ settings })
+  } catch (error) {
+    console.error('Error in settings fetch:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json()
+    const { key, value } = body
+
+    if (!key) {
+      return NextResponse.json(
+        { error: 'Missing key' },
+        { status: 400 }
+      )
+    }
+
+    const { error } = await supabase
+      .from('settings')
+      .upsert({ key, value })
+
+    if (error) {
+      console.error('Error saving setting:', error)
+      return NextResponse.json(
+        { error: 'Failed to save setting' },
+        { status: 500 }
+      )
+    }
+
+    return NextResponse.json({ success: true })
+  } catch (error) {
+    console.error('Error in settings update:', error)
+    return NextResponse.json(
+      { error: 'Internal server error' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+import { TopBar } from '@/components/TopBar'
+import { Button } from '@/components/ui/button'
+
+export default function SettingsPage() {
+  const [logoUrl, setLogoUrl] = useState('')
+  const [newUrl, setNewUrl] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  useEffect(() => {
+    const fetchSettings = async () => {
+      try {
+        const res = await fetch('/api/settings')
+        const data = await res.json()
+        if (data.settings && data.settings.logo_url) {
+          setLogoUrl(data.settings.logo_url)
+          setNewUrl(data.settings.logo_url)
+        }
+      } catch (e) {
+        console.error('Failed to load settings', e)
+      }
+    }
+    fetchSettings()
+  }, [])
+
+  const saveLogo = async () => {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/settings', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ key: 'logo_url', value: newUrl })
+      })
+      const data = await res.json()
+      if (data.error) {
+        throw new Error(data.error)
+      }
+      setLogoUrl(newUrl)
+    } catch (e) {
+      console.error('Failed to save logo', e)
+      setError('Failed to save logo')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="flex flex-col min-h-screen bg-black text-white">
+      <TopBar />
+      <main className="flex-1 mx-auto w-full max-w-5xl px-4 py-6 space-y-6">
+        <h1 className="text-xl font-light">Settings</h1>
+        <div className="space-y-2">
+          <label className="block text-sm">Logo URL</label>
+          <input
+            type="text"
+            value={newUrl}
+            onChange={e => setNewUrl(e.target.value)}
+            className="w-full p-2 bg-white/5 rounded"
+          />
+          <Button onClick={saveLogo} disabled={saving} className="mt-2">
+            Save
+          </Button>
+          {error && <p className="text-red-500 text-sm mt-2">{error}</p>}
+        </div>
+        {logoUrl && (
+          <div className="mt-6">
+            <p className="text-sm mb-2">Preview:</p>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
+            <img src={logoUrl} alt="Logo" className="h-16" />
+          </div>
+        )}
+      </main>
+    </div>
+  )
+}

--- a/src/components/TopBar.tsx
+++ b/src/components/TopBar.tsx
@@ -1,10 +1,11 @@
-import { Bot, Database } from 'lucide-react'
+import { Bot, Database, Settings } from 'lucide-react'
 import Link from 'next/link'
 import { Button } from '@/components/ui/button'
 import { ChatSettings } from '@/components/ChatSettings'
 import { usePathname } from 'next/navigation'
 import { cn } from '@/lib/utils'
 import { ChatSettings as ChatSettingsType } from '@/types'
+import { useEffect, useState } from 'react'
 
 interface TopBarProps {
   settings?: ChatSettingsType
@@ -14,16 +15,39 @@ interface TopBarProps {
 export function TopBar({ settings, onSettingsChange }: TopBarProps) {
   const pathname = usePathname()
   const isKnowledgePage = pathname === '/knowledge'
+  const isSettingsPage = pathname === '/settings'
+
+  const [logoUrl, setLogoUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    const loadLogo = async () => {
+      try {
+        const res = await fetch('/api/settings')
+        const data = await res.json()
+        if (data.settings && data.settings.logo_url) {
+          setLogoUrl(data.settings.logo_url as string)
+        }
+      } catch (e) {
+        console.error('Failed to load logo', e)
+      }
+    }
+    loadLogo()
+  }, [])
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-white/10 bg-black/50 backdrop-blur">
       <div className="mx-auto flex h-14 max-w-5xl items-center justify-between px-4">
         <div className="flex items-center gap-2">
-          <div className="rounded-full bg-white/10 p-1.5">
-            <Bot className="h-4 w-4 text-white/80" />
+          <div className="rounded-full bg-white/10 p-1.5 overflow-hidden">
+            {logoUrl ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={logoUrl} alt="Logo" className="h-4 w-4 object-contain" />
+            ) : (
+              <Bot className="h-4 w-4 text-white/80" />
+            )}
           </div>
           <span className="font-light text-white/80">
-            {isKnowledgePage ? 'Knowledge Base' : 'Chat'}
+            {isKnowledgePage ? 'Knowledge Base' : isSettingsPage ? 'Settings' : 'Chat'}
           </span>
         </div>
         <div className="flex items-center gap-2">
@@ -31,9 +55,9 @@ export function TopBar({ settings, onSettingsChange }: TopBarProps) {
             <ChatSettings settings={settings} onSettingsChange={onSettingsChange} />
           )}
           <Link href={isKnowledgePage ? '/' : '/knowledge'}>
-            <Button 
-              variant="ghost" 
-              size="sm" 
+            <Button
+              variant="ghost"
+              size="sm"
               className={cn(
                 "gap-2 text-white/60 hover:text-white hover:bg-white/5",
                 "transition-colors duration-200"
@@ -49,6 +73,18 @@ export function TopBar({ settings, onSettingsChange }: TopBarProps) {
               )}
             </Button>
           </Link>
+          {!isSettingsPage && (
+            <Link href="/settings">
+              <Button
+                variant="ghost"
+                size="sm"
+                className="gap-2 text-white/60 hover:text-white hover:bg-white/5"
+              >
+                <Settings className="h-4 w-4" />
+                Settings
+              </Button>
+            </Link>
+          )}
         </div>
       </div>
     </header>

--- a/supabase/migrations/20240324_initial_schema.sql
+++ b/supabase/migrations/20240324_initial_schema.sql
@@ -7,6 +7,7 @@ drop trigger if exists update_documents_updated_at on documents;
 drop trigger if exists update_chunks_updated_at on chunks;
 drop table if exists chunks cascade;
 drop table if exists documents cascade;
+drop table if exists settings cascade;
 drop type if exists document_status cascade;
 drop type if exists document_visibility cascade;
 
@@ -26,6 +27,12 @@ create table if not exists collections (
     metadata jsonb default '{}',
     created_at timestamptz not null default now(),
     updated_at timestamptz not null default now()
+);
+
+-- Settings table for application configuration
+create table settings (
+    key text primary key,
+    value text
 );
 
 -- Create documents table

--- a/supabase/setup.sql
+++ b/supabase/setup.sql
@@ -4,6 +4,7 @@ create extension if not exists vector;
 -- Drop existing tables if they exist
 drop table if exists chunks;
 drop table if exists documents;
+drop table if exists settings;
 
 -- Documents table
 create table documents (
@@ -14,6 +15,12 @@ create table documents (
   created_at timestamp with time zone default timezone('utc'::text, now()) not null,
   updated_at timestamp with time zone default timezone('utc'::text, now()) not null,
   status text default 'processing' not null -- 'processing', 'completed', 'error'
+);
+
+-- Simple settings table for storing branding configuration
+create table settings (
+  key text primary key,
+  value text
 );
 
 -- Chunks table with vector embeddings


### PR DESCRIPTION
## Summary
- allow storing and updating branding settings
- support retrieving and updating settings via API
- display custom logo in top bar if configured
- add settings page to change logo
- include new settings table in database setup/migration

## Testing
- `npm run lint` *(fails: next not found)*